### PR TITLE
Added a simple way to chain methods

### DIFF
--- a/quicksettings.js
+++ b/quicksettings.js
@@ -136,6 +136,8 @@
 
 		setGlobalChangeHandler: function(handler) {
 			this._globalChangeHandler = handler;
+
+			return this;
 		},
 
 		toggleCollapsed: function() {
@@ -205,6 +207,7 @@
 			this.addRange(title, min, max, value, step, function(value) {
 				object[title] = value;
 			});
+			return this;
 		},
 
 		addRange: function(title, min, max, value, step, callback) {
@@ -284,6 +287,8 @@
 			this.addBoolean(title, value, function(value) {
 				object[title] = value;
 			});
+
+			return this;
 		},
 
 		addBoolean: function(title, value, callback) {
@@ -376,6 +381,8 @@
 			this.addColor(title, color, function(value) {
 				object[title] = value;
 			});
+
+			return this;
 		},
 
 		addColor: function(title, color, callback) {
@@ -435,6 +442,9 @@
 			this.addText(title, text, function(value) {
 				object[title] = value;
 			});
+
+			return this;
+
 		},
 
 		addText: function(title, text, callback) {
@@ -531,6 +541,9 @@
 			this.addDropDown(title, items, function(value) {
 				object[title] = value.value;
 			});
+
+			return this;
+
 		},
 
 		addDropDown: function(title, items, callback) {


### PR DESCRIPTION
By return the object on the methods that add widgets we can chain methods like jQuery and other libs do. I am not sure if this is a best practice but it makes for more nicer looking code.

From
``` javascript
var settings = QuickSettings.create();
	settings.setGlobalChangeHandler(draw);
	settings.bindRange("radius", 0, 100, 50, 1, circle);
	settings.bindRange("startAngle", 0, Math.PI * 2, 0, 0.01, circle);
	settings.bindRange("endAngle", 0, Math.PI * 2, Math.PI * 2, 0.01, circle);
	settings.bindBoolean("fill", false, circle);
	settings.bindColor("fillStyle", "#ffff00", circle);
	settings.bindText("text", "hello", circle);
	settings.bindDropDown("choice", ["one", "two", "three"], circle);
```

To
``` javascript
var settings = QuickSettings.create();
	settings.setGlobalChangeHandler(draw);
	.bindRange("radius", 0, 100, 50, 1, circle)
	.bindRange("startAngle", 0, Math.PI * 2, 0, 0.01, circle)
	.bindRange("endAngle", 0, Math.PI * 2, Math.PI * 2, 0.01, circle)
	.bindBoolean("fill", false, circle)
	.bindColor("fillStyle", "#ffff00", circle)
	.bindText("text", "hello", circle)
	.bindDropDown("choice", ["one", "two", "three"], circle);
```

I have added this to only a few method as a test and everything work fine without breaking anything.