### PR TITLE
Fixed issue with setKey() function

### DIFF
--- a/quicksettings.js
+++ b/quicksettings.js
@@ -455,7 +455,7 @@
 		 */
 		setKey: function(char) {
 			this._keyCode = char.toUpperCase().charCodeAt(0);
-			document.body.addEventListener("keyup", this.onKeyUp);
+			document.body.addEventListener("keyup", this._onKeyUp);
 			return this;
 		},
 


### PR DESCRIPTION
The this.onKeyUp function does not exits. I believe what was intended is to call the this._onKeyUp function. In any case, this fixed the problem for me.
