### PR TITLE
Now setColor will set background color of label.

### DIFF
--- a/quicksettings.js
+++ b/quicksettings.js
@@ -1124,6 +1124,7 @@
 			var control = this._controls[title];
 			control.control.value = value;
 			control.label.innerHTML = "<b>" + title + ":</b> " + control.control.value;
+			control.container.getElementsByClassName("qs_color_label")[0].style.backgroundColor = control.control.value;
 			if(control.callback) {
 				control.callback(control.control.value);
 			}


### PR DESCRIPTION
When calling setColor(), the background color of the label is not updated.
1. Add a color picker
2. Call setColor from your code
   -> now the color number on qs_label, will update but not the background color of qs_color_label.

Repro on CodePen: http://codepen.io/DonKarlssonSan/pen/ALqpQZ

I'm not sure whether this is the most elegant fix but it seems to work. =)
