### PR TITLE
Update quicksettings.css

### DIFF
--- a/quicksettings.css
+++ b/quicksettings.css
@@ -148,6 +148,7 @@
 }
 .qs_checkbox {
   cursor: pointer;
+  display: inline;
 }
 .qs_checkbox input {
   position: absolute;


### PR DESCRIPTION
If you use quicksettings in combination with bootstrap, the checkbox is not visible. This will fix it. 
Other css will need this change as well...