### PR TITLE
The setKey() function should call this._onKeyUp()

### DIFF
--- a/quicksettings.js
+++ b/quicksettings.js
@@ -495,7 +495,7 @@
 		 */
 		setKey: function(char) {
 			this._keyCode = char.toUpperCase().charCodeAt(0);
-			document.body.addEventListener("keyup", this.onKeyUp);
+			document.body.addEventListener("keyup", this._onKeyUp);
 			return this;
 		},
 


### PR DESCRIPTION
There was a missing underscore before `onKeyUp()`.