### PR TITLE
The setKey() function should call this._onKeyUp() - Part 2

### DIFF
--- a/src/quicksettings.template.js
+++ b/src/quicksettings.template.js
@@ -495,7 +495,7 @@
 		 */
 		setKey: function(char) {
 			this._keyCode = char.toUpperCase().charCodeAt(0);
-			document.body.addEventListener("keyup", this.onKeyUp);
+			document.body.addEventListener("keyup", this._onKeyUp);
 			return this;
 		},
 


### PR DESCRIPTION
In [PR16](https://github.com/bit101/quicksettings/pull/16), I modified `quicksettings.js`. However, as per `Gruntfile.js`, this file is overwritten by `quicksettings.template.js`. So, I'm making the change in the right file this time. ;-)