### PR TITLE
Small fix to the latest update for addDropDown()

### DIFF
--- a/src/quicksettings.template.js
+++ b/src/quicksettings.template.js
@@ -941,7 +941,7 @@
 				var option = createElement("option"),
 					item = items[i];
 				if(item.label) {
-                	option.label = item.label;
+                	option.value = item.value;
                 	option.innerText = item.label;
 				}
                 else {


### PR DESCRIPTION
The option's value should be equal to the item's value. With that fix, it's exactly what I needed.
Cheers!