### PR TITLE
QuickSettings.setKey() should ignore bubbling events from inputs

### DIFF
--- a/src/quicksettings.template.js
+++ b/src/quicksettings.template.js
@@ -501,7 +501,9 @@
 
 		_onKeyUp: function(event) {
 			if(event.keyCode === this._keyCode) {
-				this.toggleVisibility();
+				if (["INPUT", "SELECT", "TEXTAREA"].indexOf(event.target.tagName) < 0) {
+					this.toggleVisibility();
+				}
 			}
 		},
 


### PR DESCRIPTION
When you assign a key with `setKey()`, the panel disappears if you type that key in a text field. This change prevents bubbling events from input elements (specifically `<input>`, `<select>` and `<textarea>`) from toggling panel visibility.