### PR TITLE
Added callback to addImage() method

### DIFF
--- a/src/quicksettings.template.js
+++ b/src/quicksettings.template.js
@@ -1130,10 +1130,11 @@
 		/**
 		 * Adds an image control.
 		 * @param title {String} The title of the control.
-		 * @param imageURL {String} The URL to the image.
+		 * @param imageURL {String} The URL to the image.     
+		 * @param [callback] {Function} Callback function to call when the image has fully loaded
 		 * @returns {module:QuickSettings}
 		 */
-		addImage: function(title, imageURL) {
+		addImage: function(title, imageURL, callback) {
 			var container = this._createContainer(),
 				label = createLabel("<b>" + title + "</b>", container);
 			img = createElement("img", null, "qs_image", container);
@@ -1148,6 +1149,12 @@
 				},
 				setValue: function(url) {
 					this.control.src = url;
+					if(callback) {
+						img.addEventListener("load", function _onLoad() {
+							img.removeEventListener("load", _onLoad)
+							callback(url);
+						})
+					}
 				}
 			};
 			return this;


### PR DESCRIPTION
I was in a position where, after calling `setValue()` on an image control, I needed to wait for the image to be fully loaded before working with it. I figured the logical way to do that would be to add a callback for the `addImage()` method. This is totally in line with the rest of the API and is very helpful when you need to work with the image after it has been loaded.

I did not register this function with the global change handler nor did I create a `bindImage()`method. I did not want to screw anything up... Hopefully, you'll agree with this proposition and can look at the ramifications.

Cheers!