### PR TITLE
Check for the existence of this._controls[title]

### DIFF
--- a/src/quicksettings.template.js
+++ b/src/quicksettings.template.js
@@ -192,7 +192,7 @@
                 json = JSON.parse(json);
             }
             for(var title in json) {
-                if(this._controls[title].setValue) {
+                if(this._controls[title] && this._controls[title].setValue) {
                     this._controls[title].setValue(json[title]);
                 }
             }


### PR DESCRIPTION
We need to check not only for the presence of `setValue()` but also for the existence of `this._controls[title]`. Otherwise, a non-existing control name in the JSON (or local storage) halts the whole process.