### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See http://bit101.github.com/quicksettings
 
 You can use the files from this repo in your project or directly link to the main minified js file at:
 
-- https://cdn.jsdelivr.net/quicksettings/latest/quicksettings.min.js
+- https://cdn.jsdelivr.net/npm/quicksettings@latest/quicksettings.min.js
 
 If you want to use a specific version, use the actual version number, such as "2.0" in place of "latest" in the url.
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/quicksettings.

Feel free to ping me if you have any questions regarding this change.