### PR TITLE
Update jsdoc to characterize optional parameters as such

### DIFF
--- a/quicksettings.js
+++ b/quicksettings.js
@@ -124,7 +124,7 @@
          * @param x            {Number}        x position of panel (default 0)
          * @param y            {Number}        y position of panel (default 0)
          * @param title        {String}        title of panel (default "QuickSettings")
-         * @param parent    {HTMLElement}    parent element (default document.body)
+         * @param [parent]    {HTMLElement}    parent element (default document.body)
          * @returns {module:QuickSettings}    New QuickSettings Panel
          * @static
          */
@@ -595,7 +595,7 @@
          * Changes a specific style on the given component.
          * @param title {String} The title of the control.
          * @param style {String} The name of the style.
-         * @param value {Various} The new value of the style.
+         * @param value {String} The new value of the style.
          * @returns {module:QuickSettings}
          */
         overrideStyle: function (title, style, value) {


### PR DESCRIPTION
I only fixed the ones that I stumbled upon. There might be others. I'll happily update those as well when I encounter them. When parameters are not defined as optional, omitting them in your code triggers a warning in various IDEs. 

Note regarding overrideStyle(): I believe the value for a style is always a string. If you really want to allow various types, you can use *.