### PR TITLE
Prevent mouse clicks from propagating to elements under the panel

### DIFF
--- a/quicksettings.js
+++ b/quicksettings.js
@@ -246,6 +246,7 @@
         _createPanel: function (x, y, parent) {
             this._panel = createElement("div", null, "qs_main", parent || document.body);
             this._panel.style.zIndex = ++QuickSettings._topZ;
+            this._panel.addEventListener("click", function (e) { e.stopPropagation() });
             this.setPosition(x || 0, y || 0);
             this._controls = {};
         },


### PR DESCRIPTION
In the current version, mouse clicks on the panel propagate to HTML elements under the panel, sometimes causing unintended behavior. This PR prevents that.